### PR TITLE
catch up on trillian modified paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Set `$GOPATH` variable to point to your Go workspace directory and add `$GOPATH/
 
 7. Provision a log and a map 
 ```sh
-go run $GOPATH/github.com/google/trillian/cmd/createtree/main.go --admin_server=localhost:8090 --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --tree_type=LOG
-go run $GOPATH/github.com/google/trillian/cmd/createtree/main.go --admin_server=localhost:8090 --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --tree_type=MAP
+go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=localhost:8090 --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --tree_type=LOG
+go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=localhost:8090 --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --tree_type=MAP
 ```
 
 Set the `LOG_ID` and `MAP_ID` environment variables in `docker-compose.yml` with the output

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     image: trillian_map_server:latest
     build: 
       context: ../trillian
-      dockerfile: server/vmap/trillian_map_server/Dockerfile
+      dockerfile: server/trillian_map_server/Dockerfile
     restart: always
     ports:
       - "8093:8090" # rpcs


### PR DESCRIPTION
- fix paths according to: google/trillian#643
- align `createtree` calls with default directory [layout](https://github.com/golang/go/wiki/GOPATH#directory-layout)